### PR TITLE
Adding marathon envrionments to run marathon well

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,6 +86,9 @@ Vagrant.configure(2) do |config|
      sudo yum -y install docker-engine
      echo 'docker,mesos' > /etc/mesos-slave/containerizers
      sudo bash
+     echo 'MARATHON_MASTER="zk://localhost:2181/mesos"' >> /etc/default/marathon
+     echo 'MARATHON_ZK="zk://localhost:2181/marathon"' >> /etc/default/marathon
+     echo 'MARATHON_MESOS_USER="root"' >> /etc/default/marathon
      systemctl start zookeeper
      systemctl start mesos-master
      systemctl start mesos-slave


### PR DESCRIPTION
Hi, @burakbostancioglu 

It couldn't start marathon with following error messages. so There were no running marahon process.

```
Feb  6 08:54:45 localhost marathon: [scallop] Error: Required option 'master' not found
Feb  6 08:54:45 localhost systemd: marathon.service: main process exited, code=exited, status=1/FAILURE
Feb  6 08:54:45 localhost systemd: Unit marathon.service entered failed state.
Feb  6 08:54:45 localhost systemd: marathon.service failed.
```

so I added some marathon environments into /etc/default/marathon 

ref: https://jira.mesosphere.com/browse/MARATHON-7932

Thanks.
