### PR TITLE
reorder-docker-running

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,12 +89,12 @@ Vagrant.configure(2) do |config|
      echo 'MARATHON_MASTER="zk://localhost:2181/mesos"' >> /etc/default/marathon
      echo 'MARATHON_ZK="zk://localhost:2181/marathon"' >> /etc/default/marathon
      echo 'MARATHON_MESOS_USER="root"' >> /etc/default/marathon
+     systemctl start docker
      systemctl start zookeeper
      systemctl start mesos-master
      systemctl start mesos-slave
      systemctl start marathon
      systemctl start chronos
-     systemctl start docker
 
    SHELL
 end


### PR DESCRIPTION
mesos-slave has dependency with docker.
so, docker should run before staring mesos-slave